### PR TITLE
fix(cluster-api): repair syntax error breaking dashboard login

### DIFF
--- a/netlify/functions/cluster-api.js
+++ b/netlify/functions/cluster-api.js
@@ -1353,11 +1353,8 @@ exports.handler = async (event, context) => {
       const cmd = {
         id: genId(),
         target: device_id,
-        type: "reset-restart-count","fresh-connect",
-        payload: {
-              
-              mode: "hash_text", text: "curtbrag cluster test"
-            },
+        type: "reset-restart-count",
+        payload: {},
         status: "queued",
         created_by: "operator",
         created_at: Date.now(),


### PR DESCRIPTION
## Summary
- PR #179 accidentally pasted `,"fresh-connect"` into the `type` field of the reset-restart-count cmd object literal in `cluster-api.js`, producing invalid JS.
- The Netlify function failed to load with `Runtime.UserCodeSyntaxError`, returning 502 to every endpoint behind `/.netlify/functions/cluster-api` — including `auth-check`, which is why dashboard login showed "Invalid password" no matter the input.
- Fix: restore `type` to a single string and clean the leftover stub payload on the same handler.

## Verification
- `node -c netlify/functions/cluster-api.js` parses clean.
- Production reproducer before fix: `curl -i .../cluster-api?action=auth-check` → `HTTP/2 502 Runtime.UserCodeSyntaxError: SyntaxError: Unexpected string`.

## Test plan
- [ ] Merge → wait for Netlify redeploy
- [ ] `curl -i "https://curtbrag.com/.netlify/functions/cluster-api?action=auth-check"` returns something other than 502 (401 or 4xx with JSON body is fine)
- [ ] Log in at `/cluster/dashboard` with the configured password

https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno)_