### PR TITLE
fix(pages): silence Jekyll auto-builder with _config.yml + placeholder index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,34 @@
+# This repo's site is hosted on Netlify (curtbrag.com), NOT GitHub Pages.
+# This file exists only to keep GitHub Pages' built-in Jekyll builder from
+# choking on Astro source files (the `---` Astro frontmatter looks like
+# YAML to Jekyll). To stop GitHub Pages entirely, go to Settings -> Pages
+# and set Source to "None".
+
+title: curtbrag-website
+description: Hosted on Netlify; this Pages output is unused.
+theme: jekyll-theme-primer
+
+# Hide everything that isn't a Jekyll input from Jekyll's source scan.
+exclude:
+  - .gitattributes
+  - .github/
+  - .gitignore
+  - .nojekyll
+  - CLAUDE.md
+  - DEPLOYMENT.md
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - astro.config.mjs
+  - configs/
+  - dist/
+  - netlify/
+  - netlify.toml
+  - node_modules/
+  - package-lock.json
+  - package.json
+  - public/
+  - scripts/
+  - src/
+  - tsconfig.json
+  - vendor/

--- a/index.md
+++ b/index.md
@@ -1,0 +1,9 @@
+---
+title: curtbrag-website
+---
+
+# curtbrag-website
+
+The site is live at **<https://curtbrag.com>**.
+
+This GitHub Pages output is unused — the project is hosted on Netlify. This page only exists so the Pages builder has something to render and stops failing on every push.


### PR DESCRIPTION
## Summary
Stop the GitHub Actions red Xs without touching repo Settings.

GitHub Pages is set to "Deploy from a branch" in Settings, which runs `actions/jekyll-build-pages@v1` on every push. Jekyll then tries to parse Astro files (`---` frontmatter looks like YAML to it) and fails the build — `Layout.astro`, `Footer.astro`, `Nav.astro`, `dashboard.astro` all error out.

This adds:
- `_config.yml` — excludes every non-Jekyll path so Jekyll doesn't even look at the Astro source.
- `index.md` — a single placeholder page pointing at curtbrag.com so Pages has something valid to render.

Result: Jekyll build succeeds, Pages publishes a one-page placeholder, no red Xs on push.

This is a workaround. The proper fix is **Settings → Pages → Source: None**, which can't be done from code/API.

https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno)_