### PR TITLE
fix(cluster-api): add controller/skynet targets + dashboard shortcuts

### DIFF
--- a/netlify/functions/cluster-api.js
+++ b/netlify/functions/cluster-api.js
@@ -785,7 +785,7 @@ exports.handler = async (event, context) => {
     // Queue a command
     if (postAction === "queue-command") {
       const VALID_TARGETS = [
-        "all","phones","pcs","steamdeck","viki","nexus",
+        "all","phones","pcs","steamdeck","viki","nexus","controller","skynet",
         "phone173","phone174","phone175","phone176","phone177","phone191","phone253","phone254",
       ];
       const VALID_COMMANDS = [

--- a/src/pages/cluster/dashboard.astro
+++ b/src/pages/cluster/dashboard.astro
@@ -166,6 +166,8 @@ Observed hashes from online devices:
 <button onclick="queueShortcut('nexus','mining-status')">Nexus Verify</button>
 <button onclick="queueShortcut('steamdeck','mining-start')">SteamDeck Start</button>
 <button onclick="queueShortcut('steamdeck','mining-status')">SteamDeck Verify</button>
+<button onclick="queueShortcut('controller','mining-start')">Controller Start</button>
+<button onclick="queueShortcut('controller','mining-status')">Controller Verify</button>
 </div></div>
 <div style="background:var(--color-panel);border:1px solid var(--color-border);border-radius:8px;padding:16px;margin-bottom:16px">
 <h3 style="margin-bottom:12px">Dispatch Command</h3>


### PR DESCRIPTION
Add `controller`/`skynet` to VALID_TARGETS so commands can be queued at the bridge host. Bridge already handles these targets (runs locally). Also adds Controller Start/Verify dashboard buttons.

https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno)_