### PR TITLE
feat(bridge+api): bridge pushes per-device observed state to website

### DIFF
--- a/netlify/functions/cluster-api.js
+++ b/netlify/functions/cluster-api.js
@@ -867,6 +867,24 @@ exports.handler = async (event, context) => {
       return json(200, hdrs, { ok: true });
     }
 
+    // Bridge pushes per-device state after each node command. Updates
+    // last_seen_at (so dashboard shows online) and observed state
+    // (xmrig_running, hashrate_60s, etc — so dashboard shows mining + hashrate).
+    if (postAction === "bridge-touch-device") {
+      const { hostname, observed } = body;
+      if (!hostname) return json(400, hdrs, { error: "hostname required" });
+      const all = await getAllDevices();
+      const dev = all.find((d) => d.hostname === hostname);
+      if (!dev) return json(404, hdrs, { error: `no device with hostname ${hostname}` });
+      dev.last_seen_at = Date.now();
+      await saveDevice(dev.id, dev);
+      if (observed && typeof observed === "object") {
+        const merged = { ...(await getObservedState(dev.id) || {}), ...observed, updated_at: Date.now() };
+        await openStore("cp-observed").setJSON(dev.id, merged);
+      }
+      return json(200, hdrs, { ok: true, device_id: dev.id });
+    }
+
     // Flush command queue
     if (postAction === "flush-queue") {
       await flushQueue();
@@ -1139,6 +1157,7 @@ exports.handler = async (event, context) => {
         { hostname: "viki", ip: "192.168.1.180", device_class: "pc", cluster_role: "control-plane" },
         { hostname: "nexus", ip: "192.168.1.179", device_class: "pc", cluster_role: "control-plane" },
         { hostname: "steamdeck", ip: "192.168.1.166", device_class: "steamdeck", cluster_role: "worker" },
+        { hostname: "skynet", ip: "192.168.1.188", device_class: "pc", cluster_role: "control-plane" },
       ];
       const existing = await getAllDevices();
       const existingHostnames = new Set(existing.map(d => d.hostname));

--- a/scripts/curt-cluster-bridge.example.sh
+++ b/scripts/curt-cluster-bridge.example.sh
@@ -96,7 +96,7 @@ complete_cmd() {
 
 phone_ssh() {
   local id="$1"; shift
-  timeout 25 ssh -n -p "$PHONE_PORT" -i "$SSH_KEY" \
+  timeout 60 ssh -n -p "$PHONE_PORT" -i "$SSH_KEY" \
     -o BatchMode=yes -o ConnectTimeout=5 -o ConnectionAttempts=1 \
     -o ServerAliveInterval=2 -o ServerAliveCountMax=2 \
     -o StrictHostKeyChecking=no -o LogLevel=ERROR \
@@ -105,7 +105,7 @@ phone_ssh() {
 
 linux_ssh() {
   local user="$1" ip="$2"; shift 2
-  timeout 25 ssh -n -i "$SSH_KEY" \
+  timeout 60 ssh -n -i "$SSH_KEY" \
     -o BatchMode=yes -o ConnectTimeout=5 -o ConnectionAttempts=1 \
     -o ServerAliveInterval=2 -o ServerAliveCountMax=2 \
     -o StrictHostKeyChecking=no -o LogLevel=ERROR \
@@ -324,6 +324,44 @@ run_node_cmd() {
   esac
 }
 
+# Push per-device observed state to the website (so the dashboard shows
+# real online/mining/hashrate, not "unreachable: 11").
+push_device_state() {
+  local hostname="$1" running="$2" hashrate="$3" body
+  body="$(jq -nc \
+    --arg h "$hostname" \
+    --argjson xmrig "$running" \
+    --argjson hr "${hashrate:-0}" \
+    '{hostname:$h, observed:{xmrig_running:$xmrig, hashrate_60s:$hr}}')"
+  api_post bridge-touch-device "$body" >/dev/null 2>&1 || true
+}
+
+# Hostname mapping: bridge target name → device registry hostname
+# (controller is local skynet, registered as itself if seeded; phones same name)
+device_hostname_for() {
+  case "$1" in
+    controller|skynet) hostname 2>/dev/null || echo controller ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# Best-effort parse of mining-status / mining-start output.
+# Returns "running hashrate" as space-separated string.
+parse_node_state() {
+  local out="$1" running=false hr=0
+  # If output is empty / SSH errored / no auth, skip — caller decides.
+  if echo "$out" | grep -Eq 'Permission denied|No route to host|Connection refused|Connection timed out|UNREACHABLE|UNKNOWN_TARGET'; then
+    echo "false 0"; return
+  fi
+  # xmrig running? Look for non-grep, non-tmux xmrig in PROC line.
+  if echo "$out" | grep -E '\bxmrig\b' | grep -v 'pgrep' | grep -v 'tmux' | grep -qv 'NO_XMRIG'; then
+    running=true
+  fi
+  # hashrate from "miner    speed 10s/60s/15m  X  Y  Z H/s" — Y is 60s avg.
+  hr=$(echo "$out" | awk '/miner    speed/{a=$5} END{print (a==""||a=="n/a")?0:a}')
+  echo "$running $hr"
+}
+
 execute_command() {
   local id="$1" target="$2" type="$3" output="" node node_out
   log "executing id=$id target=$target type=$type"
@@ -331,6 +369,15 @@ execute_command() {
   for node in $(target_list "$target"); do
     node_out="$(run_node_cmd "$node" "$type" 2>&1)"
     output+=$'\n===== '"$node / $type"$' =====\n'"$node_out"$'\n'
+
+    # Push observed state per device so the dashboard reflects reality.
+    if ! echo "$node_out" | grep -Eq 'Permission denied|No route to host|UNKNOWN_TARGET|UNSUPPORTED_COMMAND'; then
+      local dev_host state running hr
+      dev_host="$(device_hostname_for "$node")"
+      state="$(parse_node_state "$node_out")"
+      running="${state% *}"; hr="${state##* }"
+      push_device_state "$dev_host" "$running" "$hr"
+    fi
   done
 
   printf '%s' "$output"


### PR DESCRIPTION
Until now the bridge ran commands but never told the website what state each node was in, so the dashboard always read "Online: 0 / Unreachable: 11" even though the bridge had just SSHed to all of them.

**cluster-api.js**
- New POST `bridge-touch-device` (`{hostname, observed}`) — updates `last_seen_at` and `cp-observed` blob for the device with that hostname.
- `seed-fleet` now also seeds `skynet` so the bridge host shows up in the registry.

**scripts/curt-cluster-bridge.example.sh**
- `parse_node_state()` extracts `xmrig_running` + `hashrate_60s` from the raw output of mining-status / mining-start.
- `push_device_state()` POSTs to `bridge-touch-device` per node after each SSH (except when SSH itself errored).
- `device_hostname_for()` maps `controller`/`skynet` target to actual hostname.
- SSH timeout bumped 25 → 60s (fixes the empty-output problem we saw with linux_start where the 25s post-launch sleep got cut off).

After merge + bridge restart on skynet, dashboard Fleet/Summary populate with real state on every command run.

https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9LJJUoqm4hefxBJV63Qno)_